### PR TITLE
20250521_fix:enumメソッド衝突

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,6 @@ class User < ApplicationRecord
   
   has_many :spots, dependent: :destroy
 
-  enum role: { general: 0, admin: 1 }
+  enum role: { general: 0, admin: 1 }, _prefix: true
 
 end


### PR DESCRIPTION
#info
・enumによるメソッド衝突を避けるために推奨している書き方。
　→「, _prefix: true」を入れることにより、「def admin」と同じような書き方をしている名前と混合しないようにする。
　　enumのadminを使用する場合は「role_admin」と書く必要が出てくる。


```
$ npx @tailwindcss/cli -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --minify
≈ tailwindcss v4.1.7
Done in 68ms
Done in 0.86s.
bin/rails aborted!
ArgumentError: wrong number of arguments (given 0, expected 1..2) (ArgumentError)
/opt/render/project/src/app/models/user.rb:12:in `<class:User>'
```