### PR TITLE
20250521_fix:enumメソッド衝突-02

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,6 @@ class User < ApplicationRecord
   
   has_many :spots, dependent: :destroy
 
-  enum role: { general: 0, admin: 1 }, _prefix: true
+  enum role: { general: 0, administrator: 1 }, _prefix: true
 
 end


### PR DESCRIPTION
#info
Deviseにadminがあるためデプロイ失敗している可能性あり。
ひとまず、名前を変えてみた。